### PR TITLE
Issues #331, 332 moved teleporter to more accurate location

### DIFF
--- a/src/data/features/liyue/special/teleporter.json
+++ b/src/data/features/liyue/special/teleporter.json
@@ -392,8 +392,8 @@
       "popupMedia": "liyue/teleporter/east-tianqiu-valley"
     },
     {
-      "coordinates": [-38.50625, 14.80625],
-      "id": "8B5E26421E466AA4390BEA7AB87ABB3AEADED206",
+      "coordinates": [-38.90332, 14.73926],
+      "id": "8276F84D8B328A7D1A8B9D0439B1915AB81D9805",
       "importIds": {
         "gm_legacy": ["liyueTeleporter/31"]
       },
@@ -500,8 +500,8 @@
       "popupMedia": "liyue/teleporter/east-qingyun-peak"
     },
     {
-      "coordinates": [-26.2875, 19.025],
-      "id": "FAF9CC0D2300881A22C7203C3EB01F8D14CDDE4D",
+      "coordinates": [-26.59277, 18.83398],
+      "id": "ECE0148709A726FD4387C7B4BCED280CC7CDA234",
       "importIds": {
         "gm_legacy": ["liyueTeleporter/40"]
       },


### PR DESCRIPTION
Moved teleporter to the location specified in the following issues
https://github.com/GenshinMap/genshinmap.github.io/issues/331
https://github.com/GenshinMap/genshinmap.github.io/issues/332

done by eye/manually, not sure if this is the proper procedure. Please let me know if it is not.
ID hash generated by `hashObject()` in Util.js
